### PR TITLE
Update calcId default for dynamic formulas

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@
 * `#2187 <https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2187>`_ Test fails due to change in Numpy API
 * `#2198 <https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2198>`_ Excel is very fussy about the version number
 * `#2200 <https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2200>`_ Poor perfomance when reading workbooks with lots of named styles
+* Default ``calcId`` updated to ``191029`` so that Excel recalculates dynamic formulas
 
 
 3.1.4 (2024-06-12)

--- a/doc/simple_formulae.rst
+++ b/doc/simple_formulae.rst
@@ -29,6 +29,13 @@ True
 
 If you're trying to use a formula that isn't known this could be because you're using a formula that was not included in the initial specification. Such formulae must be prefixed with `_xlfn.` to work.
 
+When using Excel's dynamic array functions you may need to ensure that the
+workbook uses a recent ``calcId`` so that the formulas are recalculated:
+
+.. :: doctest
+
+    >>> wb.calculation.calcId = 191029
+
 
 Special formulae
 ++++++++++++++++

--- a/openpyxl/packaging/tests/data/workbook_russian_code_name.xml
+++ b/openpyxl/packaging/tests/data/workbook_russian_code_name.xml
@@ -9,5 +9,5 @@
     <sheet name="Sheet" r:id="rId1" sheetId="1"/>
   </sheets>
   <definedNames/>
-  <calcPr calcId="124519" calcMode="auto" fullCalcOnLoad="1"/>
+  <calcPr calcId="191029" calcMode="auto" fullCalcOnLoad="1"/>
 </workbook>

--- a/openpyxl/reader/tests/data/workbook_1904.xml
+++ b/openpyxl/reader/tests/data/workbook_1904.xml
@@ -8,5 +8,5 @@
     name="Blatt1" sheetId="1" state="visible" r:id="rId1" />
   </sheets>
   <definedNames />
-  <calcPr calcId="124519" fullCalcOnLoad="1" />
+  <calcPr calcId="191029" fullCalcOnLoad="1" />
 </workbook>

--- a/openpyxl/reader/tests/data/workbook_links.xml
+++ b/openpyxl/reader/tests/data/workbook_links.xml
@@ -12,5 +12,5 @@
     <externalReference xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
     r:id="rId2" />
   </externalReferences>
-  <calcPr calcId="124519" fullCalcOnLoad="1" />
+  <calcPr calcId="191029" fullCalcOnLoad="1" />
 </workbook>

--- a/openpyxl/workbook/external_link/tests/data/workbook.xml
+++ b/openpyxl/workbook/external_link/tests/data/workbook.xml
@@ -12,5 +12,5 @@
   <definedNames>
     <definedName name="THE_GREAT_ANSWER">'My Sheeet'!$D$8</definedName>
   </definedNames>
-  <calcPr calcId="124519" calcMode="auto" fullCalcOnLoad="1"/>
+  <calcPr calcId="191029" calcMode="auto" fullCalcOnLoad="1"/>
 </workbook>

--- a/openpyxl/workbook/external_link/tests/data/workbook_namedrange.xml
+++ b/openpyxl/workbook/external_link/tests/data/workbook_namedrange.xml
@@ -12,5 +12,5 @@
     <definedNames>
         <definedName name="THE_GREAT_ANSWER">'My Sheeet with a , and '''!$U$16:$U$24,'My Sheeet with a , and '''!$V$28:$V$36</definedName>
     </definedNames>
-    <calcPr calcId="124519" calcMode="auto" fullCalcOnLoad="1"/>
+    <calcPr calcId="191029" calcMode="auto" fullCalcOnLoad="1"/>
 </workbook>

--- a/openpyxl/workbook/properties.py
+++ b/openpyxl/workbook/properties.py
@@ -98,7 +98,7 @@ class CalcProperties(Serialisable):
     forceFullCalc = Bool(allow_none=True)
 
     def __init__(self,
-                 calcId=124519,
+                 calcId=191029,
                  calcMode=None,
                  fullCalcOnLoad=True,
                  refMode=None,

--- a/openpyxl/workbook/tests/data/workbook.xml
+++ b/openpyxl/workbook/tests/data/workbook.xml
@@ -9,5 +9,5 @@
     <sheet name="Sheet" r:id="rId1" state="visible" sheetId="1"/>
   </sheets>
   <definedNames/>
-  <calcPr calcId="124519" fullCalcOnLoad="1"/>
+  <calcPr calcId="191029" fullCalcOnLoad="1"/>
 </workbook>

--- a/openpyxl/workbook/tests/data/workbook_protection.xml
+++ b/openpyxl/workbook/tests/data/workbook_protection.xml
@@ -9,5 +9,5 @@
     <sheet name="Sheet" r:id="rId1" state="visible" sheetId="1"/>
   </sheets>
   <definedNames/>
-  <calcPr calcId="124519" fullCalcOnLoad="1"/>
+  <calcPr calcId="191029" fullCalcOnLoad="1"/>
 </workbook>

--- a/openpyxl/workbook/tests/test_properties.py
+++ b/openpyxl/workbook/tests/test_properties.py
@@ -43,7 +43,7 @@ class TestCalcProperties:
         calc = CalcProperties()
         xml = tostring(calc.to_tree())
         expected = """
-           <calcPr calcId="124519" fullCalcOnLoad="1" />
+           <calcPr calcId="191029" fullCalcOnLoad="1" />
         """
         diff = compare_xml(xml, expected)
         assert diff is None, diff

--- a/openpyxl/workbook/tests/test_writer.py
+++ b/openpyxl/workbook/tests/test_writer.py
@@ -45,7 +45,7 @@ class TestWorkbookWriter:
           <sheet name="Sheet1" sheetId="2" state="visible" r:id="rId2"/>
         </sheets>
           <definedNames/>
-          <calcPr calcId="124519" fullCalcOnLoad="1"/>
+          <calcPr calcId="191029" fullCalcOnLoad="1"/>
         </workbook>
         """
         diff = compare_xml(xml, expected)
@@ -81,7 +81,7 @@ class TestWorkbookWriter:
           <sheet name="Sheet" sheetId="1" state="visible" r:id="rId1"/>
         </sheets>
         <definedNames/>
-        <calcPr calcId="124519" fullCalcOnLoad="1"/>
+        <calcPr calcId="191029" fullCalcOnLoad="1"/>
         </workbook>
         """
         diff = compare_xml(xml, expected)
@@ -110,7 +110,7 @@ class TestWorkbookWriter:
         <definedNames>
           <definedName localSheetId="0" name="_xlnm.Print_Area">'D&#xFC;sseldorf Sheet'!$A$1:$D$4</definedName>
         </definedNames>
-        <calcPr calcId="124519" fullCalcOnLoad="1"/>
+        <calcPr calcId="191029" fullCalcOnLoad="1"/>
         </workbook>
         """
         diff = compare_xml(xml, expected)
@@ -139,7 +139,7 @@ class TestWorkbookWriter:
         <definedNames>
           <definedName localSheetId="0" name="_xlnm.Print_Titles">'D&#xFC;sseldorf Sheet'!$1:$5</definedName>
         </definedNames>
-        <calcPr calcId="124519" fullCalcOnLoad="1"/>
+        <calcPr calcId="191029" fullCalcOnLoad="1"/>
         </workbook>
         """
         diff = compare_xml(xml, expected)
@@ -169,7 +169,7 @@ class TestWorkbookWriter:
         <definedNames>
         <definedName localSheetId="0" hidden="1" name="_xlnm._FilterDatabase">'D&#xFC;sseldorf Sheet'!$A$1:$A$10</definedName>
         </definedNames>
-        <calcPr calcId="124519" fullCalcOnLoad="1"/>
+        <calcPr calcId="191029" fullCalcOnLoad="1"/>
         </workbook>
         """
         diff = compare_xml(xml, expected)
@@ -197,7 +197,7 @@ class TestWorkbookWriter:
         <definedNames>
         <definedName name="MyConstant">3.14</definedName>
         </definedNames>
-        <calcPr calcId="124519" fullCalcOnLoad="1"/>
+        <calcPr calcId="191029" fullCalcOnLoad="1"/>
         </workbook>
         """
         diff = compare_xml(xml, expected)
@@ -227,7 +227,7 @@ class TestWorkbookWriter:
         <definedNames>
         <definedName localSheetId="0" name="MyReference">'D&#xFC;sseldorf Sheet'!$A$1:$A$10</definedName>
         </definedNames>
-        <calcPr calcId="124519" fullCalcOnLoad="1"/>
+        <calcPr calcId="191029" fullCalcOnLoad="1"/>
         </workbook>
         """
         diff = compare_xml(xml, expected)


### PR DESCRIPTION
## Summary
- update default `calcId` to `191029` in `CalcProperties`
- document dynamic array calculation ID in release notes
- mention setting `wb.calculation.calcId` for dynamic formulas
- update tests and test data for new `calcId`

## Testing
- `pytest openpyxl/workbook/tests/test_properties.py openpyxl/workbook/tests/test_writer.py openpyxl/workbook/external_link/tests/test_external.py openpyxl/reader/tests/test_workbook.py openpyxl/packaging/tests/test_workbook.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6ff96d688332a3d97a4acfec9e54